### PR TITLE
Handle missing properties in controllers.

### DIFF
--- a/ProfilerGrailsPlugin.groovy
+++ b/ProfilerGrailsPlugin.groovy
@@ -166,10 +166,13 @@ long requests, controller actions and service method calls take."""
 
 		controller.metaClass.getProperty = { String propName ->
 			// Get the property.
-			def mp = delegate.getClass().metaClass.getMetaProperty(propName)
-			if (!mp) {
-				throw new MissingPropertyException(propName)
-			}
+            def targetMetaClass = delegate.getClass().metaClass
+            def mp = targetMetaClass.getMetaProperty(propName)
+            if (!mp) {
+                // probably a taglib or other property added via missing property on the metaclass,
+                // delegate to that since it won't be an action closure that we want to profile anyway
+                return targetMetaClass.invokeMissingProperty(delegate, propName, null, true)
+            }
 
 			def result = mp.getProperty(delegate)
 			if (result instanceof Closure) {


### PR DESCRIPTION
Don't blow up when someone tries to access a property (like a taglib namespace)
added via the missing property mechanism on the controller metaclass.

This was reported as https://github.com/tomdcc/grails-miniprofiler/issues/8 but is actually a bug in the profiler plugin code. I can only presume that properties added to controllers in earlier versions of grails were added directly rather than via missing property, so the issue wouldn't have been a problem then.
