### PR TITLE
Feature/profile templates rendering

### DIFF
--- a/grails-app/taglib/ProfiledTemplateTagLib.groovy
+++ b/grails-app/taglib/ProfiledTemplateTagLib.groovy
@@ -1,0 +1,28 @@
+import org.codehaus.groovy.grails.plugins.web.taglib.RenderTagLib
+
+class ProfiledTemplateTagLib {
+   
+   def grailsApplication, profilerLog, bufferedAppender, profilerCondition
+   
+   private shouldProfileRenderInvokation(attrs) {
+      bufferedAppender && profilerCondition?.doProfiling() && attrs.template
+   }
+   
+   Closure render = { attrs, body ->
+      if (shouldProfileRenderInvokation(attrs)) {
+         profilerLog.logEntry(originalRenderBeanClass, "template ${attrs.template}")
+         invokeOriginalRenderTagLib(attrs, body)
+         profilerLog.logExit(originalRenderBeanClass, "template ${attrs.template}")
+      }
+      else {
+         invokeOriginalRenderTagLib(attrs, body)
+      }
+   }
+
+   private invokeOriginalRenderTagLib(attrs, body) {
+      grailsApplication.mainContext.getBean(originalRenderBeanClass.name).render.call(attrs, body)
+   }
+   
+   private static Class originalRenderBeanClass = RenderTagLib
+   
+}

--- a/test/projects/default22/grails-app/controllers/TimeController.groovy
+++ b/test/projects/default22/grails-app/controllers/TimeController.groovy
@@ -4,4 +4,8 @@ class TimeController {
     def index = {
         [ time: dateService.currentTime(), message: g.message([code: 'default.home.label']) ]
     }
+    
+    def indexWithTemplate = {
+       index.call()
+    }
 }

--- a/test/projects/default22/grails-app/views/time/_displayTime.gsp
+++ b/test/projects/default22/grails-app/views/time/_displayTime.gsp
@@ -1,0 +1,2 @@
+<div id="time">Current time: ${time}</div>
+

--- a/test/projects/default22/grails-app/views/time/indexWithTemplate.gsp
+++ b/test/projects/default22/grails-app/views/time/indexWithTemplate.gsp
@@ -1,0 +1,2 @@
+<g:render template="/time/displayTime"/>
+<pre id="profile"><g:profilerOutput/></pre>


### PR DESCRIPTION
In some projects is very easy to have many templates that may contain quite a lot of "logic" (often, just service calls orchestration), specially when using the fields plugin (which I find to be one of the most powerful plugin, specially for backoffices).

So I added templates rendering profiling (aka the g.render/<g:render> calls) by overriding default render taglib. I updated the 2.2.x demo with a controller method that invokes a template. The example would result in the following:

![screen shot 2014-01-26 at 8 30 08 pm](https://f.cloud.github.com/assets/864302/2004765/4e9093ac-86c0-11e3-9d04-b03a75a36a17.png)

I intended to update the 1.3.x example as well, but I couldn't make it work even in a clean branch (attached is an image of what I obtain... It appears the logExit is not reached in the view filter).

![screen shot 2014-01-26 at 8 23 59 pm](https://f.cloud.github.com/assets/864302/2004746/751d1b4a-86bf-11e3-8ae0-ac440e3dbf58.png)

If you think is better to create a plugin that depends on this one instead of adding this to the original one, just let me know.
