### PR TITLE
Update ProfilerGrailsPlugin.groovy - protect bean scope  in profiled bean

### DIFF
--- a/ProfilerGrailsPlugin.groovy
+++ b/ProfilerGrailsPlugin.groovy
@@ -41,8 +41,6 @@ long requests, controller actions and service method calls take."""
 		if (disableProfiling) {
 			return
 		}
-		def scope = serviceClass.getPropertyValue("scope")
-		def lazyInit = serviceClass.hasProperty("lazyInit") ? serviceClass.getPropertyValue("lazyInit") : true
 
 		// First set up the appender that logs via Slf4j.
 		loggingAppender(LoggingAppender) { bean ->
@@ -89,6 +87,8 @@ long requests, controller actions and service method calls take."""
 				if (!beanConfig) {
 					continue
 				}
+				def scope = serviceClass.getPropertyValue("scope")
+				def lazyInit = serviceClass.hasProperty("lazyInit") ? serviceClass.getPropertyValue("lazyInit") : true
 
 				// If we're dealing with a TransactionProxyFactoryBean,
 				// then we can add the profiler method interceptor directly to it.

--- a/ProfilerGrailsPlugin.groovy
+++ b/ProfilerGrailsPlugin.groovy
@@ -41,6 +41,8 @@ long requests, controller actions and service method calls take."""
 		if (disableProfiling) {
 			return
 		}
+		def scope = serviceClass.getPropertyValue("scope")
+		def lazyInit = serviceClass.hasProperty("lazyInit") ? serviceClass.getPropertyValue("lazyInit") : true
 
 		// First set up the appender that logs via Slf4j.
 		loggingAppender(LoggingAppender) { bean ->
@@ -106,7 +108,10 @@ long requests, controller actions and service method calls take."""
 					springConfig.addBeanConfiguration("${serviceName}Profiled", beanConfig)
 
 					// Now create the proxy factory bean and add the method interceptor to it.
-					"$serviceName"(ProxyFactoryBean) {
+					"$serviceName"(ProxyFactoryBean) {bean ->
+						if (scope) bean.scope = scope
+						bean.lazyInit = lazyInit
+						
 						// We don't want auto-detection of interfaces,
 						// otherwise Spring will just proxy the GroovyObject
 						// interface - not what we want!


### PR DESCRIPTION
The change lets the plugin preserve the scope of profiled bean and support services  with  scope = "prototype"
